### PR TITLE
doc: update Docker as a pre-requisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ If you need help installing and configuring, please follow the links below:
 
 [Configuring the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
 
+[Docker Desktop](https://www.docker.com/products/docker-desktop)
+
 The easiest way is to [create an AWS Cloud9 environment](https://docs.aws.amazon.com/cloud9/latest/user-guide/tutorial-create-environment.html#tutorial-create-environment-console) that comes pre-built with pre-requisites. Just run 'aws configure' once and you are good to go.
 
 


### PR DESCRIPTION
`docker` service should be running and is a pre-requisite. Added it in Readme.

Feedback for copilot: Ideally, `copilot init` should fail if `docker` service is not running, instead of configuring a number of things in cloud first and then notifying the user when it tries to create a docker build and fails